### PR TITLE
`kra up`: mount local files for config

### DIFF
--- a/api/apps.go
+++ b/api/apps.go
@@ -151,7 +151,7 @@ func (c *Client) InspectApp(ctx context.Context, feedID string, appID string) (*
 }
 
 type LaunchParams struct {
-	Template  string
+	Template  io.Reader
 	Env       map[string]string
 	Namespace string
 	Detach    bool
@@ -168,10 +168,11 @@ func (c *Client) Launch(ctx context.Context, lp LaunchParams, out io.Writer) err
 	buf := bytes.Buffer{}
 
 	mw := multipart.NewWriter(&buf)
-	err := mw.WriteField("docker-compose.yml", lp.Template)
+	w, err := mw.CreateFormField("docker-compose.yml")
 	if err != nil {
 		return err
 	}
+	io.Copy(w, lp.Template)
 
 	ew, err := mw.CreateFormField(".env")
 	if err != nil {

--- a/compose/parser.go
+++ b/compose/parser.go
@@ -1,8 +1,10 @@
 package compose
 
 import (
-	"gopkg.in/yaml.v3"
+	"io"
 	"os"
+
+	"gopkg.in/yaml.v3"
 )
 
 func ParseFile(filename string) (*File, error) {
@@ -10,9 +12,13 @@ func ParseFile(filename string) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
+	return Parse(f)
+}
 
-	var file = &File{}
-	err = yaml.NewDecoder(f).Decode(file)
+func Parse(r io.Reader) (*File, error) {
+	file := &File{}
+	err := yaml.NewDecoder(r).Decode(file)
 	if err != nil {
 		return nil, err
 	}

--- a/compose/spec.go
+++ b/compose/spec.go
@@ -1,10 +1,145 @@
 package compose
 
+import (
+	"context"
+	"fmt"
+	"log"
+	"path"
+	"strings"
+)
+
 type File struct {
-	Version  string
-	Services map[string]Service
+	Version    string
+	Services   map[string]Service `yaml:"services"`
+	Volumes    map[string]any     `yaml:"volumes"`
+	Properties map[string]any     `yaml:",inline"`
 }
 
 type Service struct {
-	Image string
+	Image      string
+	Volumes    []string
+	Properties map[string]any `yaml:",inline"`
+}
+
+// VolumeDirective
+type VolumeDirective struct {
+	Source, Destination, Options string
+	local                        bool
+}
+
+// IsLocal reports whether the path is a local path
+// the matching depends on . being the first character.
+// TODO: see how docker does it
+func (vd VolumeDirective) IsLocal() bool {
+	return strings.HasPrefix(vd.Source, ".") || vd.local
+}
+
+func (vd VolumeDirective) String() string {
+	b := strings.Builder{}
+
+	b.WriteString(vd.Source)
+	b.WriteString(":")
+	b.WriteString(vd.Destination)
+	if vd.Options != "" {
+		b.WriteString(":")
+		b.WriteString(vd.Options)
+	}
+
+	return b.String()
+}
+
+func (vd VolumeDirective) withSource(newSource string) VolumeDirective {
+	vd.Source = newSource
+	return vd
+}
+
+func (s Service) parseVolumes() ([]VolumeDirective, error) {
+	out := make([]VolumeDirective, 0, len(s.Volumes))
+	for _, v := range s.Volumes {
+		vd, err := parseVolume(v)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vd)
+	}
+
+	return out, nil
+}
+
+// Rewrite rewrites the local paths in the compose spec to remote paths,
+// based on the volume name passed in
+func (s Service) Rewrite(volPrefix string) (Service, []VolumeDirective, error) {
+	v, err := s.parseVolumes()
+	if err != nil {
+		return s, nil, err
+	}
+
+	newV := v
+	for i := range v {
+		if !v[i].IsLocal() {
+			continue
+		}
+
+		newV[i] = v[i].withSource(path.Join(volPrefix, v[i].Source))
+	}
+
+	newVol := make([]string, len(newV))
+	for i := range newV {
+		newVol[i] = newV[i].String()
+	}
+
+	s.Volumes = newVol
+	return s, v, nil
+}
+
+func parseVolume(s string) (VolumeDirective, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) < 2 {
+		return VolumeDirective{}, fmt.Errorf("could not parse volume directive, only got 1 part, at least 2 are required")
+	}
+
+	v := VolumeDirective{
+		Source:      parts[0],
+		Destination: parts[1],
+	}
+
+	if len(parts) > 2 {
+		opt := strings.Join(parts[2:], ":")
+		v.Options = opt
+	}
+
+	v.local = v.IsLocal()
+	return v, nil
+}
+
+// rewriteComposeLocal takes in a compose file,
+// it parses the volumes section.
+// It generates an application function and a new spec
+// that must be handled *after* applying.
+func (f *File) Rewrite(magicVolume string) (func(ctx context.Context) error, *File, error) {
+	volumePaths := []VolumeDirective{}
+	for k := range f.Services {
+		s, p, err := f.Services[k].Rewrite(path.Join(magicVolume, k))
+		if err != nil {
+			return nil, nil, fmt.Errorf("error rewriting service %q: %w", k, err)
+		}
+
+		for _, path := range p {
+			if path.IsLocal() {
+				volumePaths = append(volumePaths, path)
+			}
+		}
+
+		f.Services[k] = s
+	}
+
+	if len(volumePaths) > 0 {
+		f.Volumes[magicVolume] = struct{}{}
+	}
+
+	return func(ctx context.Context) error {
+		log.Println("create volume, mount files here", volumePaths)
+
+		return nil
+	}, f, nil
 }

--- a/compose/spec_test.go
+++ b/compose/spec_test.go
@@ -1,0 +1,45 @@
+package compose_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kraudcloud/cli/compose"
+	"gopkg.in/yaml.v3"
+)
+
+const s = `version: '3.9'
+services:
+  a:
+    image: abc:latest
+    container_name: abc
+    labels:
+      abc: d
+    volumes:
+      - ./script.sh:mount/it/there
+      - volume:/var/data
+`
+
+func TestRewrite(t *testing.T) {
+	file := &compose.File{}
+	err := yaml.NewDecoder(strings.NewReader(s)).Decode(file)
+	if err != nil {
+		t.Errorf("error parsing file: %s", err)
+		return
+	}
+
+	for i := range file.Services {
+		s, _, err := file.Services[i].Rewrite("magic")
+		if err != nil {
+			t.Errorf("error rewriting service: %s", err)
+		}
+		file.Services[i] = s
+	}
+
+	out, err := yaml.Marshal(file)
+	if err != nil {
+		t.Errorf("error rewriting service: %s", err)
+	}
+
+	t.Log(string(out))
+}


### PR DESCRIPTION
`kra` now parses the spec, finding the volumes directive that point to local files.

If it finds some, it rewrites the path to a fictional remote path on a volume.

This volume is then created through the usual process, and finally, we upload the local files through webdav to the remote volume.

This has a few flaws:

1. If the transfer of files takes too long and the container starts before, files will just appear in the volume *after* startup, so it might loop restart.
2. Webdav is slow. This is not great for large files.
3. We use the same volume for all config values. This *may* be a security issue since containers *may* be able to read other's configuration values.
4. Cleanup: Cleanup is manual from the user's side. These config volumes should probably be deleted along with the namespace, rather than kept around like other volumes.

Solutions:

1. We need to be able to create the specified volume in the specified namespace *ahead* of time, to be able to upload files to it, before creating the volumes. `kraud` has no backend path to do this as of now.
2. Compress files and to improve throughput.
3. Use seperate volumes; though this comes with it's own set of challenges: 
  - Size: We can't just allocate a 10G volume for each config. Probably stat the whole thing beforehand
  - Speed & Reliability: Creating a lot of volumes client side means we lose some reproducibility. Might have to do SAGA to avoid leaving volumes with sensitive data hanging.
4. Tag volumes appropriately
